### PR TITLE
fix(typo): typo in framework.md

### DIFF
--- a/content/docs/framework.md
+++ b/content/docs/framework.md
@@ -6,7 +6,7 @@ title: 프레임워크
 
 ## TailwindCSS
 
-[PostCSS](https://postcss.org), [TailwindCSS](https://tailwindcss.com/) 가 티도리 프레임워크 템플릿에 포함되어 있습니다. 따라서 스타일 태그로 따로 분리하지 않아도 사용할 수 있습니다. 스타일이 대부분의 코드를 차지하는 티스토리 스킨의 특성상 TailwindCSS 와 함께 사용하면 생산성에서 큰 이점을 볼 수 있습니다. TailwindCSS 를 사용하기 위해서는 `@tailiwnd base`, `@tailiwnd components`, `@tailiwnd utilities` 를 포함해야 하는데, 기본 템플릿에서 **asserts/app.css** 를 살펴보면 다음과 같은 코드가 있습니다.
+[PostCSS](https://postcss.org), [TailwindCSS](https://tailwindcss.com/) 가 티도리 프레임워크 템플릿에 포함되어 있습니다. 따라서 스타일 태그로 따로 분리하지 않아도 사용할 수 있습니다. 스타일이 대부분의 코드를 차지하는 티스토리 스킨의 특성상 TailwindCSS 와 함께 사용하면 생산성에서 큰 이점을 볼 수 있습니다. TailwindCSS 를 사용하기 위해서는 `@tailiwnd base`, `@tailiwnd components`, `@tailiwnd utilities` 를 포함해야 하는데, 기본 템플릿에서 **assets/app.css** 를 살펴보면 다음과 같은 코드가 있습니다.
 
 ```css
 @tailwind base;


### PR DESCRIPTION
안녕하세요! 공식문서를 읽는 중 오타가 발견되어 제보합니다.

framework.md 문서에 오타가 존재합니다.

assets/app.css 로 표시되어야 하는 부분이 

asserts/app.css 로 오기되어 있습니다. (문자 r 오기)

asserts/app.css -> assets/app.css